### PR TITLE
fix upfile file fd check error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -204,7 +204,7 @@ static void uwsc_onopen(struct uwsc_client *cl)
 
 static void write_file(char *msg, uint64_t len)
 {
-    if (upfile) {
+    if (upfile > 0) {
         if (write(upfile, msg, len) < 0) {
             ULOG_ERR("upfile failed:%s\n", strerror(errno));
             close(upfile);


### PR DESCRIPTION
检测 upfile 如果为 -1时,判断条件会出错