### PR TITLE
fix bug #18

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -500,7 +500,7 @@ static void uwsc_onclose(struct uwsc_client *cl)
         pkt = NULL;
     }
 
-    avl_remove_all_elements(&tty_sessions, tty, avl, tmp)
+    avl_for_each_element_safe(&tty_sessions, tty, avl, tmp)
         del_tty_session(tty);
 
     cl->send(cl, NULL, 0, WEBSOCKET_OP_CLOSE);


### PR DESCRIPTION
avl_delete() can not be invoked in avl_remove_all_elements(), but
it can be invoked in avl_for_each_element_safe().