### PR TITLE
Feature/mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,12 @@ Replace the following parameters with your own parameters
 
     sudo rtty -I 'My-device-ID' -h 'your-server' -p 5912 -a -v -d 'My Device Description'
 
-If your rttys is configured with a key and certificate, add the following parameters(Replace the following with valid paths to your own)
+If your rttys is configured with mTLS enabled (device key and certificate required), add the following parameters(Replace the following with valid paths to your own)
 
     -k /etc/ssl/private/abc.pem -c /etc/ssl/certs/abc.pem
+
+You can generate them e.g. via openssl tool
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp521r1 -keyout /tmp/key.pem -out /tmp/cert.pem -days 18262 -nodes -subj "/C=CZ/O=Acme Inc./OU=ACME/CN=ACME-DEV-123"
 
 If your rttys is configured with a token, add the following parameter(Replace the following token with your own)
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Select rtty in menuconfig and compile it
         -d, --description=string Adding a description to the device(Maximum 126 bytes)
         -a                       Auto reconnect to the server
         -s                       SSL on
+        -k, --key                Device key (PEM file) for mTLS\n"
+        -c, --cert               Device certificate (PEM file) for mTLS\n"
         -D                       Run in the background
         -t, --token=string       Authorization token
         -f username              Skip a second login authentication. See man login(1) about the details
@@ -108,6 +110,10 @@ Select rtty in menuconfig and compile it
 Replace the following parameters with your own parameters
 
     sudo rtty -I 'My-device-ID' -h 'your-server' -p 5912 -a -v -d 'My Device Description'
+
+If your rttys is configured with a key and certificate, add the following parameters(Replace the following with valid paths to your own)
+
+    -k /etc/ssl/private/abc.pem -c /etc/ssl/certs/abc.pem
 
 If your rttys is configured with a token, add the following parameter(Replace the following token with your own)
 

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,8 @@ static struct option long_options[] = {
     {"port",        required_argument, NULL, 'p'},
     {"description", required_argument, NULL, 'd'},
     {"token",       required_argument, NULL, 't'},
+    {"key",         required_argument, NULL, 'k'},
+    {"cert",        required_argument, NULL, 'c'},
     {"verbose",     no_argument,       NULL, 'v'},
     {"version",     no_argument,       NULL, 'V'},
     {"help",        no_argument,       NULL, LONG_OPT_HELP},
@@ -65,6 +67,8 @@ static void usage(const char *prog)
             "      -d, --description=string Adding a description to the device(Maximum 126 bytes)\n"
             "      -a                       Auto reconnect to the server\n"
             "      -s                       SSL on\n"
+            "      -k, --key                Device key (PEM file) for mTLS\n"
+            "      -c, --cert               Device certificate (PEM file) for mTLS\n"
             "      -D                       Run in the background\n"
             "      -t, --token=string       Authorization token\n"
             "      -f username              Skip a second login authentication. See man login(1) about the details\n"
@@ -93,7 +97,7 @@ int main(int argc, char **argv)
     int c;
 
     while (true) {
-        c = getopt_long(argc, argv, "I:h:p:d:asDt:f:RS:vV", long_options, &option_index);
+        c = getopt_long(argc, argv, "I:h:p:d:ask:c:Dt:f:RS:vV", long_options, &option_index);
         if (c == -1)
             break;
 
@@ -119,6 +123,12 @@ int main(int argc, char **argv)
             break;
         case 's':
             rtty.ssl_on = true;
+            break;
+        case 'k':
+            rtty.ssl_key = optarg;
+            break;
+        case 'c':
+            rtty.ssl_cert = optarg;
             break;
         case 'D':
             background = true;

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -429,7 +429,7 @@ static void on_net_connected(int sock, void *arg)
 
     if (rtty->ssl_on) {
 #if (RTTY_SSL_SUPPORT)
-        rtty_ssl_init((struct rtty_ssl_ctx **)&rtty->ssl, sock, rtty->host);
+        rtty_ssl_init((struct rtty_ssl_ctx **)&rtty->ssl, sock, rtty->host, rtty->ssl_key, rtty->ssl_cert);
 #endif
     }
 

--- a/src/rtty.h
+++ b/src/rtty.h
@@ -69,6 +69,8 @@ struct rtty {
     const char *description;
     const char *username;
     bool ssl_on;
+    const char *ssl_key;      /* path to device key */
+    const char *ssl_cert;     /* path to device cert */
     struct buffer rb;
     struct buffer wb;
     struct ev_io iow;

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -34,7 +34,7 @@
 
 struct rtty_ssl_ctx;
 
-int rtty_ssl_init(struct rtty_ssl_ctx **ctx, int sock, const char *host);
+int rtty_ssl_init(struct rtty_ssl_ctx **ctx, int sock, const char *host, const char *key, const char *cert);
 
 void rtty_ssl_free(struct rtty_ssl_ctx *ctx);
 


### PR DESCRIPTION
add client mTLS support
This enables more secure device connection
Certificate and key is stored in PEM format, files are specified by -k/-c variables in CLI

This requires mTLS support in rttys