### PR TITLE
feat:add /var/run/rtty file to get the state of rtty

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
 #include <glob.h>
 
 #include "log/log.h"
+#include "utils.h"
 #include "rtty.h"
 
 enum {
@@ -240,6 +241,8 @@ int main(int argc, char **argv)
     if (rtty.ssl_ctx && !has_cacert)
         load_default_ca_cert(rtty.ssl_ctx);
 #endif
+
+	rtty_run_state(RTTY_STATE_DISCONNECTED);
 
     if (rtty_start(&rtty) < 0)
         return -1;

--- a/src/rtty.c
+++ b/src/rtty.c
@@ -289,6 +289,8 @@ void rtty_exit(struct rtty *rtty)
 
     http_conns_free(&rtty->http_conns);
 
+	rtty_run_state(RTTY_STATE_DISCONNECTED);
+
     if (!rtty->reconnect)
         ev_break(rtty->loop, EVBREAK_ALL);
 }
@@ -399,6 +401,7 @@ static int parse_msg(struct rtty *rtty)
             }
             buffer_pull(rb, NULL, msglen - 1);
             log_info("register success\n");
+			rtty_run_state(RTTY_STATE_CONNECTED);
             break;
 
         case MSG_TYPE_LOGIN:

--- a/src/utils.c
+++ b/src/utils.c
@@ -29,8 +29,10 @@
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "utils.h"
+#include "log/log.h"
 
 int find_login(char *buf, int len)
 {
@@ -221,4 +223,39 @@ bool getgid_by_pid(pid_t pid, gid_t *gid)
     sscanf(line, "Gid:\t%u", gid);
     
     return true;
+}
+
+void rtty_run_state(int state)
+{
+	static int _st = -1;
+	const char *rtty_statefile = "/var/run/rtty";
+	FILE *sf;
+	const char *str_state = "Disconnected\n";
+
+	if (_st == state) {
+		return;	
+	}
+
+	_st = state;
+
+	sf = fopen(rtty_statefile, "w+");
+	if (!sf) {
+		log_err("Cannot create state %s: %s", rtty_statefile, strerror(errno));
+		return;
+	}
+
+	switch(_st){
+	case RTTY_STATE_CONNECTED:
+		str_state = "Connected\n";
+		break;
+	default:
+		break;
+	}
+
+	fwrite(str_state, strlen(str_state), 1, sf);
+
+	fsync(fileno(sf));
+	fclose(sf);
+
+	return;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -44,4 +44,11 @@ bool getuid_by_pid(pid_t pid, uid_t *uid);
 
 bool getgid_by_pid(pid_t pid, gid_t *gid);
 
+enum {
+	RTTY_STATE_CONNECTED = 1,
+	RTTY_STATE_DISCONNECTED
+};
+
+void rtty_run_state(int state);
+
 #endif


### PR DESCRIPTION
Other programs, such as Luci, can display the connection status of the
program by reading /var/run/rtty

Signed-off-by: Jiajian Zhou <zhou_0611@163.com>